### PR TITLE
add support for most common operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,20 @@ All defined s-expressions are listed here, though this specification will be exp
 - Atomic s-expressions (atoms):
   - Numbers
   - Strings
-  - Variable names
+  - Identifiers
+    - Variable names
+    - Reserved identifiers: `True`, `False`, and `None`
+      - Cannot be used as variable names
 
 - Composite s-expressions:
   - Lists: `(list <item>*)`
   - Attributes: `(attr <object> <attribute>)`
     - `attribute` must be a string literal
   - Function calls: `(call <function> <argument>*)`
+  - Unary operators: `(<operator> <operand>)`
+    - `<operator>` must be `not` (Boolean)
   - Binary operators: `(<operator> <operand> <operand>)`
-      - `<operator>` must be one of `+`, `-`, `*`, or `/`
+      - `<operator>` must be one of `+`, `-`, `*`, `/`, 'and', 'or', `==`, `!=`, `<`, `<=`, `>`, `>=`
   - Lambdas: `(lambda <arguments> <expression>)`
     - `arguments` must be a `list` containing only variable names
   - Select: `(Select <source> <selector>)`

--- a/ast_language/syntax.lark
+++ b/ast_language/syntax.lark
@@ -32,4 +32,4 @@ composite: "(" [WHITESPACE] NODE_TYPE (WHITESPACE node)* [WHITESPACE] ")"
 
 NODE_TYPE: LETTER+ | OPERATOR_SYMBOL
 
-OPERATOR_SYMBOL: "*" | "+" | "-" | "/"
+OPERATOR_SYMBOL: "*" | "+" | "-" | "/" | "==" | "!=" | "<=" | "<" | ">=" | ">"

--- a/ast_language/transform.py
+++ b/ast_language/transform.py
@@ -23,8 +23,10 @@ Compare_ops = {'==': ast.Eq,
                '>':  ast.Gt,
                '>=': ast.GtE}
 
-op_strings = {value: key for dictionary in [UnaryOp_ops, BinOp_ops, BoolOp_ops, Compare_ops]
-                         for key, value in dictionary.items()}
+op_strings = {value: key
+              for dictionary in [UnaryOp_ops, BinOp_ops, BoolOp_ops, Compare_ops]
+              for key, value in dictionary.items()}
+
 
 class PythonASTToTextASTTransformer(ast.NodeVisitor):
     def visit_Module(self, node):
@@ -220,7 +222,9 @@ class TextASTToPythonASTTransformer(lark.Transformer):
 
         elif node_type in Compare_ops:
             if len(fields) == 2:
-                return ast.Compare(left=fields[0], ops=[Compare_ops[node_type]()], comparators=[fields[1]])
+                return ast.Compare(left=fields[0],
+                                   ops=[Compare_ops[node_type]()],
+                                   comparators=[fields[1]])
             else:
                 raise SyntaxError(Compare_ops[node_type]
                                   + ' operator only supported for two operands; found '

--- a/ast_language/transform.py
+++ b/ast_language/transform.py
@@ -145,9 +145,10 @@ class TextASTToPythonASTTransformer(lark.Transformer):
     def atom(self, children):
         child = children[0]
         if child.type == 'IDENTIFIER':
-            if child.value in ['True', 'False', 'None']:
+            if child.value in ['True', 'False', 'None'] and sys.version_info[0] > 2:
                 return ast.NameConstant(value=ast.literal_eval(child.value))
-            return ast.Name(id=child.value, ctx=ast.Load())
+            else:
+                return ast.Name(id=child.value, ctx=ast.Load())
         elif child.type == 'STRING_LITERAL':
             return ast.Str(s=ast.literal_eval(child.value))
         elif child.type == 'NUMERIC_LITERAL':

--- a/ast_language/transform.py
+++ b/ast_language/transform.py
@@ -6,18 +6,25 @@ import ast
 import sys
 
 
-binary_operator_strings = {ast.Add:  '+',
-                           ast.Sub:  '-',
-                           ast.Mult: '*',
-                           ast.Div:  '/'}
+UnaryOp_ops = {'not': ast.Not}
 
-comparison_operator_strings = {ast.Eq:    '==',
-                               ast.NotEq: '!=',
-                               ast.Lt:    '<',
-                               ast.LtE:   '<=',
-                               ast.Gt:    '>',
-                               ast.GtE:   '>='}
+BinOp_ops = {'+': ast.Add,
+             '-': ast.Sub,
+             '*': ast.Mult,
+             '/': ast.Div}
 
+BoolOp_ops = {'and': ast.And,
+              'or':  ast.Or}
+
+Compare_ops = {'==': ast.Eq,
+               '!=': ast.NotEq,
+               '<':  ast.Lt,
+               '<=': ast.LtE,
+               '>':  ast.Gt,
+               '>=': ast.GtE}
+
+op_strings = {value: key for dictionary in [UnaryOp_ops, BinOp_ops, BoolOp_ops, Compare_ops]
+                         for key, value in dictionary.items()}
 
 class PythonASTToTextASTTransformer(ast.NodeVisitor):
     def visit_Module(self, node):
@@ -41,6 +48,9 @@ class PythonASTToTextASTTransformer(ast.NodeVisitor):
 
     def visit_Str(self, node):
         return repr(node.s)
+
+    def visit_NameConstant(self, node):
+        return repr(node.value)
 
     @staticmethod
     def make_composite_node_string(node_type, *fields):
@@ -70,17 +80,29 @@ class PythonASTToTextASTTransformer(ast.NodeVisitor):
             else:
                 raise SyntaxError('Unsupported unary - operand type: ' + type(node.operand))
         else:
-            raise SyntaxError('Unsupported unary operator: ' + type(node.op))
+            return self.make_composite_node_string(op_strings[type(node.op)],
+                                                   self.visit(node.operand))
 
     def visit_BinOp(self, node):
-        return self.make_composite_node_string(binary_operator_strings[type(node.op)],
+        return self.make_composite_node_string(op_strings[type(node.op)],
                                                self.visit(node.left),
                                                self.visit(node.right))
+
+    def visit_BoolOp(self, node):
+        if len(node.values) < 2:
+            raise SyntaxError('Boolean operator must have at least 2 operands; found: '
+                              + len(node.values))
+        rep = self.visit(node.values[0])
+        for value in node.values[1:]:
+            rep = self.make_composite_node_string(op_strings[type(node.op)],
+                                                  rep,
+                                                  self.visit(value))
+        return rep
 
     def visit_Compare(self, node):
         rep = self.visit(node.left)
         for operator, comparator in zip(node.ops, node.comparators):
-            rep = self.make_composite_node_string(comparison_operator_strings[type(operator)],
+            rep = self.make_composite_node_string(op_strings[type(operator)],
                                                   rep,
                                                   self.visit(comparator))
         return rep
@@ -121,6 +143,8 @@ class TextASTToPythonASTTransformer(lark.Transformer):
     def atom(self, children):
         child = children[0]
         if child.type == 'IDENTIFIER':
+            if child.value in ['True', 'False', 'None']:
+                return ast.NameConstant(value=ast.literal_eval(child.value))
             return ast.Name(id=child.value, ctx=ast.Load())
         elif child.type == 'STRING_LITERAL':
             return ast.Str(s=ast.literal_eval(child.value))
@@ -170,77 +194,36 @@ class TextASTToPythonASTTransformer(lark.Transformer):
             else:
                 return ast.Call(func=fields[0], args=fields[1:], keywords=[])
 
-        elif node_type == '*':
-            if len(fields) == 2:
-                return ast.BinOp(left=fields[0], op=ast.Mult(), right=fields[1])
-            else:
-                raise SyntaxError('* operator only supported for two operands; found '
-                                  + len(fields))
-        elif node_type == '+':
+        elif node_type in UnaryOp_ops:
             if len(fields) == 1:
-                return ast.UnaryOp(op=ast.UAdd(), operand=fields[0])
-            elif len(fields) == 2:
-                return ast.BinOp(left=fields[0], op=ast.Add(), right=fields[1])
+                return ast.UnaryOp(op=UnaryOp_ops[node_type](), operand=fields[0])
             else:
-                raise SyntaxError('+ operator only supported for one or two operands; found '
-                                  + len(fields))
-        elif node_type == '-':
-            if len(fields) == 1:
-                if isinstance(fields[0], ast.Num) and sys.version_info < 3:
-                    return ast.Num(n=-fields[0].n)
-                else:
-                    return ast.UnaryOp(op=ast.USub(), operand=fields[0])
-            elif len(fields) == 2:
-                return ast.BinOp(left=fields[0], op=ast.Sub(), right=fields[1])
-            else:
-                raise SyntaxError('- operator only supported for one or two operands; found '
-                                  + len(fields))
-        elif node_type == '/':
-            if len(fields) == 2:
-                return ast.BinOp(left=fields[0], op=ast.Div(), right=fields[1])
-            else:
-                raise SyntaxError('/ operator only supported for two operands; found '
+                raise SyntaxError(UnaryOp_ops[node_type]
+                                  + ' operator only supported for one operand; found '
                                   + len(fields))
 
-        elif node_type == '==':
+        elif node_type in BinOp_ops:
             if len(fields) == 2:
-                return ast.Compare(left=fields[0], ops=[ast.Eq()], comparators=[fields[1]])
+                return ast.BinOp(left=fields[0], op=BinOp_ops[node_type](), right=fields[1])
             else:
-                raise SyntaxError('== operator only supported for two operands; found '
-                                  + len(fields))
-        elif node_type == '!=':
-            if len(fields) == 2:
-                return ast.Compare(left=fields[0], ops=[ast.NotEq()], comparators=[fields[1]])
-            else:
-                raise SyntaxError('!= operator only supported for two operands; found '
+                raise SyntaxError(BinOp_ops[node_type]
+                                  + ' operator only supported for two operands; found '
                                   + len(fields))
 
-        elif node_type == '<':
+        elif node_type in BoolOp_ops:
             if len(fields) == 2:
-                return ast.Compare(left=fields[0], ops=[ast.Lt()], comparators=[fields[1]])
+                return ast.BoolOp(op=BoolOp_ops[node_type](), values=fields)
             else:
-                raise SyntaxError('< operator only supported for two operands; found '
+                raise SyntaxError(BoolOp_ops[node_type]
+                                  + ' operator only supported for two operands; found '
                                   + len(fields))
 
-        elif node_type == '<=':
+        elif node_type in Compare_ops:
             if len(fields) == 2:
-                return ast.Compare(left=fields[0], ops=[ast.LtE()], comparators=[fields[1]])
+                return ast.Compare(left=fields[0], ops=[Compare_ops[node_type]()], comparators=[fields[1]])
             else:
-                raise SyntaxError('<= operator only supported for two operands; found '
-                                  + len(fields))
-
-        elif node_type == '>':
-            if len(fields) == 2:
-                return ast.Compare(left=fields[0], ops=[ast.Gt()], comparators=[fields[1]])
-            else:
-                raise SyntaxError('> operator only supported for two operands; found '
-                                  + len(fields))
-
-        elif node_type == '>=':
-            if len(fields) == 2:
-                return ast.Compare(left=fields[0], ops=[ast.GtE()], comparators=[fields[1]])
-            else:
-                raise SyntaxError('>= operator only supported for two operands; found '
+                raise SyntaxError(Compare_ops[node_type]
+                                  + ' operator only supported for two operands; found '
                                   + len(fields))
 
         elif node_type == 'lambda':

--- a/ast_language/transform.py
+++ b/ast_language/transform.py
@@ -11,6 +11,13 @@ binary_operator_strings = {ast.Add:  '+',
                            ast.Mult: '*',
                            ast.Div:  '/'}
 
+comparison_operator_strings = {ast.Eq:    '==',
+                               ast.NotEq: '!=',
+                               ast.Lt:    '<',
+                               ast.LtE:   '<=',
+                               ast.Gt:    '>',
+                               ast.GtE:   '>='}
+
 
 class PythonASTToTextASTTransformer(ast.NodeVisitor):
     def visit_Module(self, node):
@@ -69,6 +76,14 @@ class PythonASTToTextASTTransformer(ast.NodeVisitor):
         return self.make_composite_node_string(binary_operator_strings[type(node.op)],
                                                self.visit(node.left),
                                                self.visit(node.right))
+
+    def visit_Compare(self, node):
+        rep = self.visit(node.left)
+        for operator, comparator in zip(node.ops, node.comparators):
+            rep = self.make_composite_node_string(comparison_operator_strings[type(operator)],
+                                                  rep,
+                                                  self.visit(comparator))
+        return rep
 
     def visit_Lambda(self, node):
         return self.make_composite_node_string('lambda',
@@ -185,6 +200,47 @@ class TextASTToPythonASTTransformer(lark.Transformer):
                 return ast.BinOp(left=fields[0], op=ast.Div(), right=fields[1])
             else:
                 raise SyntaxError('/ operator only supported for two operands; found '
+                                  + len(fields))
+
+        elif node_type == '==':
+            if len(fields) == 2:
+                return ast.Compare(left=fields[0], ops=[ast.Eq()], comparators=[fields[1]])
+            else:
+                raise SyntaxError('== operator only supported for two operands; found '
+                                  + len(fields))
+        elif node_type == '!=':
+            if len(fields) == 2:
+                return ast.Compare(left=fields[0], ops=[ast.NotEq()], comparators=[fields[1]])
+            else:
+                raise SyntaxError('!= operator only supported for two operands; found '
+                                  + len(fields))
+
+        elif node_type == '<':
+            if len(fields) == 2:
+                return ast.Compare(left=fields[0], ops=[ast.Lt()], comparators=[fields[1]])
+            else:
+                raise SyntaxError('< operator only supported for two operands; found '
+                                  + len(fields))
+
+        elif node_type == '<=':
+            if len(fields) == 2:
+                return ast.Compare(left=fields[0], ops=[ast.LtE()], comparators=[fields[1]])
+            else:
+                raise SyntaxError('<= operator only supported for two operands; found '
+                                  + len(fields))
+
+        elif node_type == '>':
+            if len(fields) == 2:
+                return ast.Compare(left=fields[0], ops=[ast.Gt()], comparators=[fields[1]])
+            else:
+                raise SyntaxError('> operator only supported for two operands; found '
+                                  + len(fields))
+
+        elif node_type == '>=':
+            if len(fields) == 2:
+                return ast.Compare(left=fields[0], ops=[ast.GtE()], comparators=[fields[1]])
+            else:
+                raise SyntaxError('>= operator only supported for two operands; found '
                                   + len(fields))
 
         elif node_type == 'lambda':

--- a/ast_language/transform.py
+++ b/ast_language/transform.py
@@ -102,11 +102,21 @@ class PythonASTToTextASTTransformer(ast.NodeVisitor):
         return rep
 
     def visit_Compare(self, node):
-        rep = self.visit(node.left)
-        for operator, comparator in zip(node.ops, node.comparators):
-            rep = self.make_composite_node_string(op_strings[type(operator)],
-                                                  rep,
-                                                  self.visit(comparator))
+        if len(node.ops) < 1:
+            raise SyntaxError('Compare node must have at least 1 operation; found: '
+                              + len(node.ops))
+        left = self.visit(node.left)
+        right = self.visit(node.comparators[0])
+        rep = self.make_composite_node_string(op_strings[type(node.ops[0])],
+                                              left,
+                                              right)
+        for operator, comparator in zip(node.ops[1:], node.comparators[1:]):
+            left = right
+            right = self.visit(comparator)
+            new_comparison = self.make_composite_node_string(op_strings[type(operator)],
+                                                             left,
+                                                             right)
+            rep = self.make_composite_node_string('and', rep, new_comparison)
         return rep
 
     def visit_Lambda(self, node):

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/doc/ebnf.md
+++ b/doc/ebnf.md
@@ -64,6 +64,9 @@ composite = "(", [whitespace],
 
 node type = letter, {letter} | operator symbol ;
 
-operator symbol = "*" | "+" | "-" | "/" ;
+operator symbol =   "*" | "+" | "-" | "/"
+                  | "=", "=" | "!", "="
+                  | "<", "=" | "<"
+                  | ">", "=" | ">" ;
 
 ```

--- a/tests/test_ast_language.py
+++ b/tests/test_ast_language.py
@@ -102,6 +102,15 @@ def test_binary_operators():
     assert_equivalent_python_text_and_text_ast('1 / 2', "(/ 1 2)")
 
 
+def test_comparison_operators():
+    assert_equivalent_python_text_and_text_ast('1 == 2', "(== 1 2)")
+    assert_equivalent_python_text_and_text_ast('1 != 2', "(!= 1 2)")
+    assert_equivalent_python_text_and_text_ast('1 < 2', "(< 1 2)")
+    assert_equivalent_python_text_and_text_ast('1 <= 2', "(<= 1 2)")
+    assert_equivalent_python_text_and_text_ast('1 > 2', "(> 1 2)")
+    assert_equivalent_python_text_and_text_ast('1 >= 2', "(>= 1 2)")
+
+
 def test_lambda():
     assert_equivalent_python_text_and_text_ast('lambda: 0', "(lambda (list) 0)")
     assert_equivalent_python_text_and_text_ast('lambda x, y, z: x', "(lambda (list x y z) x)")

--- a/tests/test_ast_language.py
+++ b/tests/test_ast_language.py
@@ -105,9 +105,8 @@ def test_binary_operators():
 
 def test_boolean_operators():
     assert_equivalent_python_text_and_text_ast('True and False', "(and True False)")
-    assert python_source_to_text_ast('a and b and c') == '(and (and a b) c)'
     assert_equivalent_python_text_and_text_ast('True or False', "(or True False)")
-    assert python_source_to_text_ast('a or b or c') == '(or (or a b) c)'
+    assert python_source_to_text_ast('a and b and c') == '(and (and a b) c)'
 
 
 def test_comparison_operators():
@@ -117,6 +116,8 @@ def test_comparison_operators():
     assert_equivalent_python_text_and_text_ast('1 <= 2', "(<= 1 2)")
     assert_equivalent_python_text_and_text_ast('1 > 2', "(> 1 2)")
     assert_equivalent_python_text_and_text_ast('1 >= 2', "(>= 1 2)")
+    assert python_source_to_text_ast('1 < 2 < 3') == '(and (< 1 2) (< 2 3))'
+    assert python_source_to_text_ast('1 < 2 < 3 < 4') == '(and (and (< 1 2) (< 2 3)) (< 3 4))'
 
 
 def test_lambda():

--- a/tests/test_ast_language.py
+++ b/tests/test_ast_language.py
@@ -93,6 +93,7 @@ def test_unary_operators():
     assert_ast_nodes_are_equal(text_ast_to_python_ast('+1'), ast.parse('1'))
     assert python_source_to_text_ast('-1') == '-1'
     assert_ast_nodes_are_equal(text_ast_to_python_ast('-1'), ast.parse('-1'))
+    assert_equivalent_python_text_and_text_ast('not True', "(not True)")
 
 
 def test_binary_operators():
@@ -100,6 +101,11 @@ def test_binary_operators():
     assert_equivalent_python_text_and_text_ast('1 - 2', "(- 1 2)")
     assert_equivalent_python_text_and_text_ast('1 * 2', "(* 1 2)")
     assert_equivalent_python_text_and_text_ast('1 / 2', "(/ 1 2)")
+
+
+def test_boolean_operators():
+    assert_equivalent_python_text_and_text_ast('True and False', "(and True False)")
+    assert_equivalent_python_text_and_text_ast('True or False', "(or True False)")
 
 
 def test_comparison_operators():

--- a/tests/test_ast_language.py
+++ b/tests/test_ast_language.py
@@ -105,7 +105,9 @@ def test_binary_operators():
 
 def test_boolean_operators():
     assert_equivalent_python_text_and_text_ast('True and False', "(and True False)")
+    assert python_source_to_text_ast('a and b and c') == '(and (and a b) c)'
     assert_equivalent_python_text_and_text_ast('True or False', "(or True False)")
+    assert python_source_to_text_ast('a or b or c') == '(or (or a b) c)'
 
 
 def test_comparison_operators():


### PR DESCRIPTION
Comparison operators seem to be working. Python handles compositions of comparisons (e.g., `1 < 2 < 3`) in an odd way, though, so I'll have to deal with that if I want the text AST -> Python AST translation to exactly match `ast.parse`.